### PR TITLE
Add missing <body> opening tag

### DIFF
--- a/blank-starter.html
+++ b/blank-starter.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" type="text/css" href="css/app.css">
     <script src="js/vendor/modernizr.js"></script>
 </head>
+<body>
 <div class="page-wrap"><!-- We use this wrapper to make the footer sticky -->
     <div id="branding-bar-v1" itemscope="itemscope" itemtype="http://schema.org/CollegeOrUniversity">
         <div class="bar">


### PR DESCRIPTION
The 'starter' page was missing an opening `<body>` tag. This PR adds it.